### PR TITLE
Support LiveActivity when streaming is active in background

### DIFF
--- a/Playground.xcodeproj/project.pbxproj
+++ b/Playground.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 60;
+	objectVersion = 70;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -16,6 +16,11 @@
 		74312CDC2E1D02E3000D994A /* MacAudioDevicesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74312CDB2E1D02E3000D994A /* MacAudioDevicesView.swift */; };
 		74312CDE2E1DA46C000D994A /* StreamResultView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74312CDD2E1DA46C000D994A /* StreamResultView.swift */; };
 		74359A2D2E28261A008C31EF /* VoiceEnergyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74359A2C2E28261A008C31EF /* VoiceEnergyView.swift */; };
+		7435D4382E4E8673008167D7 /* Argmax in Frameworks */ = {isa = PBXBuildFile; productRef = 7435D4372E4E8673008167D7 /* Argmax */; };
+		7446C90B2E4D522B00290EAB /* LiveActivityManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7446C9052E4D522B00290EAB /* LiveActivityManager.swift */; };
+		7446C9152E4D536400290EAB /* WidgetKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7446C9142E4D536400290EAB /* WidgetKit.framework */; };
+		7446C9172E4D536400290EAB /* SwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7446C9162E4D536400290EAB /* SwiftUI.framework */; };
+		7446C9242E4D536500290EAB /* TranscriptionLiveActivityExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 7446C9122E4D536400290EAB /* TranscriptionLiveActivityExtension.appex */; platformFilter = ios; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		7469F1FA2E3AC3D00090AEBA /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = 7469F1F92E3AC3D00090AEBA /* README.md */; };
 		746E4C062E39874F009623D7 /* DefaultEnvInitializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 746E4C042E39874F009623D7 /* DefaultEnvInitializer.swift */; };
 		746E4C0A2E398757009623D7 /* PlaygroundEnvInitializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 746E4C082E398757009623D7 /* PlaygroundEnvInitializer.swift */; };
@@ -23,7 +28,6 @@
 		747E67062E3008000061E778 /* TranscribeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 747E67052E3008000061E778 /* TranscribeViewModel.swift */; };
 		747E67082E300F780061E778 /* TranscribeResultView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 747E67072E300F780061E778 /* TranscribeResultView.swift */; };
 		748BA5502E1B2EC6008DA1B8 /* StreamViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 748BA54F2E1B2EC6008DA1B8 /* StreamViewModel.swift */; };
-		74CE73D72E3C40D900919F36 /* Argmax in Frameworks */ = {isa = PBXBuildFile; productRef = 74CE73D62E3C40D900919F36 /* Argmax */; };
 		74F3B7BC2E1C7C8B00C544D1 /* ToastMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74F3B7BB2E1C7C8B00C544D1 /* ToastMessage.swift */; };
 		74F3B7BE2E1CF44F00C544D1 /* AudioProcessDiscoverer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74F3B7BD2E1CF44F00C544D1 /* AudioProcessDiscoverer.swift */; };
 		74F3B7C12E1CF4F400C544D1 /* AudioProcess.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74F3B7C02E1CF4F400C544D1 /* AudioProcess.swift */; };
@@ -31,6 +35,16 @@
 		74F860962E2B19060007163C /* CoreAudioUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74F860952E2B19060007163C /* CoreAudioUtils.swift */; };
 		74F897792E4F9B130045252E /* TranscriptionModeSelection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74F897782E4F9B130045252E /* TranscriptionModeSelection.swift */; };
 /* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		7446C9222E4D536500290EAB /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 167B34562B05431E0076F261 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 7446C9112E4D536400290EAB;
+			remoteInfo = TranscriptionLiveActivityExtension;
+		};
+/* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
 		1621BFDF2B74BF6E007FA014 /* Embed Watch Content */ = {
@@ -53,6 +67,17 @@
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		7446C9292E4D536500290EAB /* Embed Foundation Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				7446C9242E4D536500290EAB /* TranscriptionLiveActivityExtension.appex in Embed Foundation Extensions */,
+			);
+			name = "Embed Foundation Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
@@ -68,6 +93,11 @@
 		74312CDB2E1D02E3000D994A /* MacAudioDevicesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacAudioDevicesView.swift; sourceTree = "<group>"; };
 		74312CDD2E1DA46C000D994A /* StreamResultView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamResultView.swift; sourceTree = "<group>"; };
 		74359A2C2E28261A008C31EF /* VoiceEnergyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceEnergyView.swift; sourceTree = "<group>"; };
+		743C1DE72E4BBB75000482CC /* TranscriptionModeSelection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptionModeSelection.swift; sourceTree = "<group>"; };
+		7446C9052E4D522B00290EAB /* LiveActivityManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveActivityManager.swift; sourceTree = "<group>"; };
+		7446C9122E4D536400290EAB /* TranscriptionLiveActivityExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = TranscriptionLiveActivityExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		7446C9142E4D536400290EAB /* WidgetKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WidgetKit.framework; path = System/Library/Frameworks/WidgetKit.framework; sourceTree = SDKROOT; };
+		7446C9162E4D536400290EAB /* SwiftUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftUI.framework; path = System/Library/Frameworks/SwiftUI.framework; sourceTree = SDKROOT; };
 		7469F1F92E3AC3D00090AEBA /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		746E4C042E39874F009623D7 /* DefaultEnvInitializer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultEnvInitializer.swift; sourceTree = "<group>"; };
 		746E4C082E398757009623D7 /* PlaygroundEnvInitializer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaygroundEnvInitializer.swift; sourceTree = "<group>"; };
@@ -83,12 +113,42 @@
 		74F897782E4F9B130045252E /* TranscriptionModeSelection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptionModeSelection.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
+/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		7446C9252E4D536500290EAB /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Info.plist,
+			);
+			target = 7446C9112E4D536400290EAB /* TranscriptionLiveActivityExtension */;
+		};
+		7446C92D2E4D553500290EAB /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				TranscriptionAttributes.swift,
+			);
+			target = 167B345D2B05431E0076F261 /* Playground */;
+		};
+/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		7446C9182E4D536400290EAB /* TranscriptionLiveActivity */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (7446C92D2E4D553500290EAB /* PBXFileSystemSynchronizedBuildFileExceptionSet */, 7446C9252E4D536500290EAB /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = TranscriptionLiveActivity; sourceTree = "<group>"; };
+/* End PBXFileSystemSynchronizedRootGroup section */
+
 /* Begin PBXFrameworksBuildPhase section */
 		167B345B2B05431E0076F261 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				74CE73D72E3C40D900919F36 /* Argmax in Frameworks */,
+				7435D4382E4E8673008167D7 /* Argmax in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		7446C90F2E4D536400290EAB /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				7446C9172E4D536400290EAB /* SwiftUI.framework in Frameworks */,
+				7446C9152E4D536400290EAB /* WidgetKit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -139,6 +199,7 @@
 				74312CDB2E1D02E3000D994A /* MacAudioDevicesView.swift */,
 				74359A2C2E28261A008C31EF /* VoiceEnergyView.swift */,
 				747E67072E300F780061E778 /* TranscribeResultView.swift */,
+				743C1DE72E4BBB75000482CC /* TranscriptionModeSelection.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -148,6 +209,8 @@
 			children = (
 				7469F1F92E3AC3D00090AEBA /* README.md */,
 				1677AFA82B57618A008C61C0 /* Playground */,
+				7446C9182E4D536400290EAB /* TranscriptionLiveActivity */,
+				7446C9132E4D536400290EAB /* Frameworks */,
 				167B345F2B05431E0076F261 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -156,6 +219,7 @@
 			isa = PBXGroup;
 			children = (
 				167B345E2B05431E0076F261 /* Playground.app */,
+				7446C9122E4D536400290EAB /* TranscriptionLiveActivityExtension.appex */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -164,8 +228,18 @@
 			isa = PBXGroup;
 			children = (
 				740F6DA32E2DB07400429FE9 /* ArgmaxSDKCoordinator.swift */,
+				7446C9052E4D522B00290EAB /* LiveActivityManager.swift */,
 			);
 			path = Services;
+			sourceTree = "<group>";
+		};
+		7446C9132E4D536400290EAB /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				7446C9142E4D536400290EAB /* WidgetKit.framework */,
+				7446C9162E4D536400290EAB /* SwiftUI.framework */,
+			);
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 		746E4C052E39874F009623D7 /* Environment */ = {
@@ -218,18 +292,42 @@
 				167B345C2B05431E0076F261 /* Resources */,
 				1621BFDF2B74BF6E007FA014 /* Embed Watch Content */,
 				168D3C722C9D57EE00C688E2 /* Embed Frameworks */,
+				7446C9292E4D536500290EAB /* Embed Foundation Extensions */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				7446C9232E4D536500290EAB /* PBXTargetDependency */,
+			);
+			name = Playground;
+			packageProductDependencies = (
+				7435D4372E4E8673008167D7 /* Argmax */,
+			);
+			productName = BasicExample;
+			productReference = 167B345E2B05431E0076F261 /* Playground.app */;
+			productType = "com.apple.product-type.application";
+		};
+		7446C9112E4D536400290EAB /* TranscriptionLiveActivityExtension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 7446C9262E4D536500290EAB /* Build configuration list for PBXNativeTarget "TranscriptionLiveActivityExtension" */;
+			buildPhases = (
+				7446C90E2E4D536400290EAB /* Sources */,
+				7446C90F2E4D536400290EAB /* Frameworks */,
+				7446C9102E4D536400290EAB /* Resources */,
 			);
 			buildRules = (
 			);
 			dependencies = (
 			);
-			name = Playground;
-			packageProductDependencies = (
-				74CE73D62E3C40D900919F36 /* Argmax */,
+			fileSystemSynchronizedGroups = (
+				7446C9182E4D536400290EAB /* TranscriptionLiveActivity */,
 			);
-			productName = BasicExample;
-			productReference = 167B345E2B05431E0076F261 /* Playground.app */;
-			productType = "com.apple.product-type.application";
+			name = TranscriptionLiveActivityExtension;
+			packageProductDependencies = (
+			);
+			productName = TranscriptionLiveActivityExtension;
+			productReference = 7446C9122E4D536400290EAB /* TranscriptionLiveActivityExtension.appex */;
+			productType = "com.apple.product-type.app-extension";
 		};
 /* End PBXNativeTarget section */
 
@@ -238,11 +336,14 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
-				LastSwiftUpdateCheck = 1520;
+				LastSwiftUpdateCheck = 1630;
 				LastUpgradeCheck = 1620;
 				TargetAttributes = {
 					167B345D2B05431E0076F261 = {
 						CreatedOnToolsVersion = 15.0.1;
+					};
+					7446C9112E4D536400290EAB = {
+						CreatedOnToolsVersion = 16.3;
 					};
 				};
 			};
@@ -256,13 +357,14 @@
 			);
 			mainGroup = 167B34552B05431E0076F261;
 			packageReferences = (
-				74CE73D52E3C40D900919F36 /* XCRemoteSwiftPackageReference "argmax-sdk-swift" */,
+				7435D4362E4E8673008167D7 /* XCRemoteSwiftPackageReference "argmax-sdk-swift" */,
 			);
 			productRefGroup = 167B345F2B05431E0076F261 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
 				167B345D2B05431E0076F261 /* Playground */,
+				7446C9112E4D536400290EAB /* TranscriptionLiveActivityExtension */,
 			);
 		};
 /* End PBXProject section */
@@ -275,6 +377,13 @@
 				1677AFC42B57618A008C61C0 /* Preview Assets.xcassets in Resources */,
 				7469F1FA2E3AC3D00090AEBA /* README.md in Resources */,
 				1677AFE12B57678E008C61C0 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		7446C9102E4D536400290EAB /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -294,6 +403,7 @@
 				740F6DA12E2CD3ED00429FE9 /* AudioDeviceDiscoverer.swift in Sources */,
 				746E4C062E39874F009623D7 /* DefaultEnvInitializer.swift in Sources */,
 				1677AFC22B57618A008C61C0 /* Playground.swift in Sources */,
+				7446C90B2E4D522B00290EAB /* LiveActivityManager.swift in Sources */,
 				748BA5502E1B2EC6008DA1B8 /* StreamViewModel.swift in Sources */,
 				74F897792E4F9B130045252E /* TranscriptionModeSelection.swift in Sources */,
 				746E4C0A2E398757009623D7 /* PlaygroundEnvInitializer.swift in Sources */,
@@ -307,7 +417,23 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		7446C90E2E4D536400290EAB /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		7446C9232E4D536500290EAB /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			platformFilter = ios;
+			target = 7446C9112E4D536400290EAB /* TranscriptionLiveActivityExtension */;
+			targetProxy = 7446C9222E4D536500290EAB /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
 		167B34832B05431F0076F261 /* Debug */ = {
@@ -533,6 +659,67 @@
 			};
 			name = Release;
 		};
+		7446C9272E4D536500290EAB /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = AU48358P93;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = TranscriptionLiveActivity/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = TranscriptionLiveActivity;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.argmaxinc.example.Playground${DEVELOPMENT_TEAM}.TranscriptionLiveActivity";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		7446C9282E4D536500290EAB /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = AU48358P93;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = TranscriptionLiveActivity/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = TranscriptionLiveActivity;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.argmaxinc.example.Playground${DEVELOPMENT_TEAM}.TranscriptionLiveActivity";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -554,23 +741,32 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
+		7446C9262E4D536500290EAB /* Build configuration list for PBXNativeTarget "TranscriptionLiveActivityExtension" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				7446C9272E4D536500290EAB /* Debug */,
+				7446C9282E4D536500290EAB /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		74CE73D52E3C40D900919F36 /* XCRemoteSwiftPackageReference "argmax-sdk-swift" */ = {
+		7435D4362E4E8673008167D7 /* XCRemoteSwiftPackageReference "argmax-sdk-swift" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "argmaxinc.argmax-sdk-swift";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 1.7.2;
+				minimumVersion = 1.7.6;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		74CE73D62E3C40D900919F36 /* Argmax */ = {
+		7435D4372E4E8673008167D7 /* Argmax */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 74CE73D52E3C40D900919F36 /* XCRemoteSwiftPackageReference "argmax-sdk-swift" */;
+			package = 7435D4362E4E8673008167D7 /* XCRemoteSwiftPackageReference "argmax-sdk-swift" */;
 			productName = Argmax;
 		};
 /* End XCSwiftPackageProductDependency section */

--- a/Playground/Info.plist
+++ b/Playground/Info.plist
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSSupportsLiveActivities</key>
+	<true/>
+	<key>NSSupportsLiveActivitiesFrequentUpdates</key>
+	<true/>
 	<key>NSAudioCaptureUsageDescription</key>
 	<string>Required to record audio from other apps for transcription.</string>
 	<key>NSPrivacyAccessedAPITypes</key>

--- a/Playground/Playground.swift
+++ b/Playground/Playground.swift
@@ -76,9 +76,11 @@ struct Playground: App {
         )
         self._audioProcessDiscoverer = StateObject(wrappedValue: processDiscoverer)
         #else
+        let liveActivityMgr = LiveActivityManager()
         let streamVM = StreamViewModel(
             sdkCoordinator: coordinator,
-            audioDeviceDiscoverer: deviceDiscoverer
+            audioDeviceDiscoverer: deviceDiscoverer,
+            liveActivityManager: liveActivityMgr
         )
         #endif
         let transcribeVM = TranscribeViewModel(sdkCoordinator: coordinator)

--- a/Playground/Services/LiveActivityManager.swift
+++ b/Playground/Services/LiveActivityManager.swift
@@ -1,0 +1,142 @@
+#if os(iOS)
+import ActivityKit
+import Foundation
+import Argmax
+
+/// Manages live activity lifecycle for transcription sessions
+/// 
+/// Handles starting, updating, and stopping live activities when the app enters
+/// background mode during stream transcription. Integrates with the transcription
+/// pipeline to provide real-time status updates across iOS presentation contexts.
+/// 
+/// Key responsibilities:
+/// - Activity lifecycle management (start/stop/update)
+/// - Background/foreground state coordination
+/// - Real-time content state updates
+/// - Error handling and cleanup
+@MainActor
+class LiveActivityManager: ObservableObject {
+    private var currentActivity: Activity<TranscriptionAttributes>?
+    private var isAppInBackground = false
+    private var bufferedContentState = TranscriptionAttributes.ContentState(
+        currentHypothesis: "",
+        hasVoice: false,
+        audioSeconds: 0.0,
+        isInterrupted: true
+    )
+    
+    // Throttling to limit updates to once per second
+    private var lastUpdateTime: TimeInterval = 0
+    private var pendingUpdate = false
+    
+    /// Starts a live activity for the current transcription session
+    /// - Parameters:
+    ///   - sessionId: Unique identifier for the transcription session
+    /// - Throws: ActivityKit errors if activity cannot be started
+    func startActivity(sessionId: String) async throws {
+        guard ActivityAuthorizationInfo().areActivitiesEnabled else {
+            Logging.error("Live Activities are not enabled")
+            return
+        }
+        
+        guard currentActivity == nil else {
+            Logging.error("Live activity already running")
+            return
+        }
+        
+        let attributes = TranscriptionAttributes(
+            sessionId: sessionId
+        )
+        
+        let initialContentState = TranscriptionAttributes.ContentState(
+            currentHypothesis: "",
+            hasVoice: false,
+            audioSeconds: 0.0,
+            isInterrupted: true
+        )
+        bufferedContentState = initialContentState
+        
+        do {
+            let activity = try Activity.request(
+                attributes: attributes,
+                content: .init(state: initialContentState, staleDate: nil)
+            )
+            
+            currentActivity = activity
+            Logging.error("Live activity started successfully: \(activity.id)")
+        } catch {
+            Logging.error("Failed to start live activity: \(error)")
+            throw error
+        }
+    }
+    
+    /// Updates the buffered content state with throttling to limit to once per second, too frequent update to dynamic island will be throttled
+    /// - Parameter updateBlock: Block that modifies the content state
+    func updateContentState(updateBlock: (TranscriptionAttributes.ContentState) -> TranscriptionAttributes.ContentState) async {
+        guard currentActivity != nil else { return }
+        
+        let oldState = bufferedContentState
+        let newState = updateBlock(oldState)
+        
+        // Only proceed if state actually changed
+        guard newState != bufferedContentState else { return }
+        
+        bufferedContentState = newState
+        
+        let now = Date().timeIntervalSince1970
+        let timeSinceLastUpdate = now - lastUpdateTime
+        
+        // Throttle updates to maximum once per second
+        if timeSinceLastUpdate >= 1.0 {
+            await performUpdate()
+        } else if !pendingUpdate {
+            // Schedule a delayed update
+            pendingUpdate = true
+            Task {
+                try? await Task.sleep(nanoseconds: UInt64((1.0 - timeSinceLastUpdate) * 1_000_000_000))
+                if pendingUpdate {
+                    await performUpdate()
+                }
+            }
+        }
+    }
+    
+    /// Performs the actual Live Activity update
+    private func performUpdate() async {
+        guard let activity = currentActivity else { return }
+        
+        lastUpdateTime = Date().timeIntervalSince1970
+        pendingUpdate = false
+        
+        await activity.update(.init(state: bufferedContentState, staleDate: nil))
+    }
+    
+    /// Stops the current live activity
+    /// - Parameter dismissalPolicy: How to dismiss the activity
+    func stopActivity(dismissalPolicy: ActivityUIDismissalPolicy = .default) async {
+        guard let activity = currentActivity else {
+            return
+        }
+        
+        await activity.end(nil, dismissalPolicy: .immediate)
+        currentActivity = nil
+    }
+    
+    /// Indicates whether a live activity is currently running
+    var isActivityRunning: Bool {
+        currentActivity != nil
+    }
+    
+    /// Handles app entering background state
+    /// Should be called when app backgrounding is detected
+    func appDidEnterBackground() {
+        isAppInBackground = true
+    }
+    
+    /// Handles app entering foreground state
+    /// Should be called when app foregrounding is detected
+    func appDidEnterForeground() {
+        isAppInBackground = false
+    }
+}
+#endif

--- a/Playground/Views/ContentView.swift
+++ b/Playground/Views/ContentView.swift
@@ -40,6 +40,7 @@ import Hub
 struct ContentView: View {
     @EnvironmentObject private var streamViewModel: StreamViewModel
     @EnvironmentObject private var transcribeViewModel: TranscribeViewModel
+    @Environment(\.scenePhase) private var scenePhase
     #if os(macOS)
     @EnvironmentObject private var audioProcessDiscoverer: AudioProcessDiscoverer
     #endif
@@ -523,6 +524,18 @@ struct ContentView: View {
                     selectedModel = firstModel
                 }
             }
+        }
+        .onChange(of: scenePhase) { _, newPhase in
+            #if os(iOS)
+            switch newPhase {
+            case .background:
+                streamViewModel.liveActivityManager.appDidEnterBackground()
+            case .active:
+                streamViewModel.liveActivityManager.appDidEnterForeground()
+            default:
+                break
+            }
+            #endif
         }
     }
 
@@ -2492,9 +2505,11 @@ extension Color {
         keyProvider: ObfuscatedKeyProvider(mask: 12)
     )
     let deviceDiscoverer = AudioDeviceDiscoverer()
+    let liveActivityManager = LiveActivityManager()
     let streamViewModel = StreamViewModel(
         sdkCoordinator: sdkCoordinator,
-        audioDeviceDiscoverer: deviceDiscoverer
+        audioDeviceDiscoverer: deviceDiscoverer,
+        liveActivityManager: liveActivityManager
     )
     let transcribeViewModel = TranscribeViewModel(
         sdkCoordinator: sdkCoordinator

--- a/Playground/Views/StreamResultView.swift
+++ b/Playground/Views/StreamResultView.swift
@@ -141,9 +141,11 @@ struct StreamResultView: View {
         keyProvider: ObfuscatedKeyProvider(mask: 12)
     )
     let deviceDiscoverer = AudioDeviceDiscoverer()
+    let liveActivityManager = LiveActivityManager()
     let streamViewModel = StreamViewModel(
         sdkCoordinator: sdkCoordinator,
-        audioDeviceDiscoverer: deviceDiscoverer
+        audioDeviceDiscoverer: deviceDiscoverer,
+        liveActivityManager: liveActivityManager
     )
     #endif
 

--- a/TranscriptionLiveActivity/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/TranscriptionLiveActivity/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TranscriptionLiveActivity/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/TranscriptionLiveActivity/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,35 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "tinted"
+        }
+      ],
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TranscriptionLiveActivity/Assets.xcassets/Contents.json
+++ b/TranscriptionLiveActivity/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TranscriptionLiveActivity/Assets.xcassets/WidgetBackground.colorset/Contents.json
+++ b/TranscriptionLiveActivity/Assets.xcassets/WidgetBackground.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TranscriptionLiveActivity/Info.plist
+++ b/TranscriptionLiveActivity/Info.plist
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.widgetkit-extension</string>
+	</dict>
+</dict>
+</plist>

--- a/TranscriptionLiveActivity/TranscriptionAttributes.swift
+++ b/TranscriptionLiveActivity/TranscriptionAttributes.swift
@@ -1,0 +1,30 @@
+#if os(iOS)
+import ActivityKit
+import Foundation
+
+/// Defines the static attributes and dynamic state for transcription live activities
+/// 
+/// This struct provides the configuration for displaying real-time transcription status
+/// when the app is running in background stream mode. Shows current transcription
+/// hypothesis across different iOS presentation contexts including Dynamic Island, 
+/// Lock Screen, and StandBy mode.
+struct TranscriptionAttributes: ActivityAttributes {
+    /// Static configuration that doesn't change during the live activity session
+    public struct ContentState: Codable, Hashable {
+        /// Current transcription hypothesis text being processed
+        var currentHypothesis: String
+        
+        /// Whether voice is currently being detected above silence threshold
+        var hasVoice: Bool
+        
+        /// Duration of audio processed in seconds
+        var audioSeconds: Double
+        
+        /// Whether audio stream has been interrupted (no data received for >0.5s)
+        var isInterrupted: Bool
+    }
+    
+    /// Static identifier for the transcription session
+    let sessionId: String
+}
+#endif

--- a/TranscriptionLiveActivity/TranscriptionLiveActivity.swift
+++ b/TranscriptionLiveActivity/TranscriptionLiveActivity.swift
@@ -1,0 +1,183 @@
+import ActivityKit
+import WidgetKit
+import SwiftUI
+
+/// A simple indicator for voice activity - when there is voice, turn on the red indicator
+struct VoiceActivityIndicator: View {
+    let hasVoice: Bool
+    var body: some View {
+        Circle()
+            .frame(width: 8, height: 8)
+            .padding(.leading, 4)
+            .foregroundStyle(hasVoice ? .red : .red.opacity(0.35))
+            .animation(.easeInOut(duration: 0.1), value: hasVoice)
+    }
+}
+
+struct TranscriptionLiveActivity: Widget {
+    var body: some WidgetConfiguration {
+        ActivityConfiguration(for: TranscriptionAttributes.self) { context in
+            // Lock screen/banner UI
+            LockScreenLiveActivityView(context: context)
+        } dynamicIsland: { context in
+            DynamicIsland {
+                DynamicIslandExpandedRegion(.leading) {
+                    HStack {
+                        VoiceActivityIndicator(hasVoice: context.state.hasVoice)
+                        Text(context.state.isInterrupted ? "Interrupted" : "Transcribing...")
+                            .font(.caption2)
+                            .foregroundColor(.secondary)
+                    }
+                    .padding(.leading, 8)
+                }
+                
+                DynamicIslandExpandedRegion(.trailing) {
+                    Text(formatDuration(context.state.audioSeconds))
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
+                        .padding(.trailing, 8)
+                }
+                
+                DynamicIslandExpandedRegion(.bottom) {
+                    VStack(alignment: .leading, spacing: 4) {
+                        if context.state.isInterrupted {
+                            Text("Microphone session interrupted. Restart transcription from the app.\n")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                                .frame(minHeight: 32, alignment: .topLeading)
+                        } else if !context.state.currentHypothesis.isEmpty {
+                            Text(context.state.currentHypothesis)
+                                .font(.caption)
+                                .lineLimit(nil)
+                                .truncationMode(.head)
+                                .frame(minHeight: 32, alignment: .topLeading)
+                                .fixedSize(horizontal: false, vertical: true)
+                        } else {
+                            Text("Listening...\n")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                                .frame(minHeight: 32, alignment: .topLeading)
+                        }
+                    }
+                    .padding(.horizontal, 8)
+                }
+            } compactLeading: {
+                VoiceActivityIndicator(hasVoice: context.state.hasVoice)
+            } compactTrailing: {
+                EmptyView()
+            } minimal: {
+                VoiceActivityIndicator(hasVoice: context.state.hasVoice)
+            }
+        }
+    }
+    
+    /// Formats duration in seconds to MM:SS format
+    /// - Parameter seconds: Duration in seconds
+    /// - Returns: Formatted time string
+    private func formatDuration(_ seconds: Double) -> String {
+        let minutes = Int(seconds) / 60
+        let remainingSeconds = Int(seconds) % 60
+        return String(format: "%d:%02d", minutes, remainingSeconds)
+    }
+}
+
+/// Lock screen live activity view component
+///
+/// Displays comprehensive transcription information optimized for lock screen presentation
+/// including current hypothesis and transcription status.
+struct LockScreenLiveActivityView: View {
+    let context: ActivityViewContext<TranscriptionAttributes>
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            // Header with Argmax branding
+            HStack {
+                HStack(spacing: 8) {
+                    VoiceActivityIndicator(hasVoice: context.state.hasVoice)
+                    Text(context.state.isInterrupted ? "Interrupted" : "Transcribing...")
+                        .font(.headline)
+                        .fontWeight(.medium)
+                }
+                
+                Spacer()
+            }
+            if context.state.isInterrupted {
+                Text("Microphone session interrupted. Restart transcription from the app.\n")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                    .frame(minHeight: 32, alignment: .topLeading)
+            } else if !context.state.currentHypothesis.isEmpty {
+                Text(context.state.currentHypothesis)
+                    .font(.body)
+                    .lineLimit(3)
+                    .truncationMode(.head)
+            } else {
+                Text("Listening...")
+                    .font(.body)
+                    .foregroundColor(.secondary)
+            }
+        }
+        .padding(16)
+        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 16))
+    }
+}
+
+#Preview("Live Activity", as: .content, using: TranscriptionAttributes.preview) {
+    TranscriptionLiveActivity()
+} contentStates: {
+    TranscriptionAttributes.ContentState.sampleActive
+    TranscriptionAttributes.ContentState.sampleListening
+    TranscriptionAttributes.ContentState.sampleCompleted
+}
+
+#Preview("Dynamic Island Compact", as: .dynamicIsland(.compact), using: TranscriptionAttributes.preview) {
+    TranscriptionLiveActivity()
+} contentStates: {
+    TranscriptionAttributes.ContentState.sampleActive
+}
+
+#Preview("Dynamic Island Expanded", as: .dynamicIsland(.expanded), using: TranscriptionAttributes.preview) {
+    TranscriptionLiveActivity()
+} contentStates: {
+    TranscriptionAttributes.ContentState.sampleActive
+    TranscriptionAttributes.ContentState.sampleListening
+}
+
+// MARK: - Preview Data
+
+extension TranscriptionAttributes {
+    static var preview: TranscriptionAttributes {
+        TranscriptionAttributes(
+            sessionId: "preview-session-123"
+        )
+    }
+}
+
+extension TranscriptionAttributes.ContentState {
+    static var sampleActive: TranscriptionAttributes.ContentState {
+        TranscriptionAttributes.ContentState(
+            currentHypothesis: "This is a sample transcription showing real-time voice recognition in progress.",
+            hasVoice: true,
+            audioSeconds: 45.2,
+            isInterrupted: false
+        )
+    }
+    
+    static var sampleListening: TranscriptionAttributes.ContentState {
+        TranscriptionAttributes.ContentState(
+            currentHypothesis: "",
+            hasVoice: false,
+            audioSeconds: 12.1,
+            isInterrupted: false
+        )
+    }
+    
+    static var sampleCompleted: TranscriptionAttributes.ContentState {
+        TranscriptionAttributes.ContentState(
+            currentHypothesis: "Transcription session completed successfully with final results.",
+            hasVoice: false,
+            audioSeconds: 120.0,
+            isInterrupted: false
+        )
+    }
+}

--- a/TranscriptionLiveActivity/TranscriptionLiveActivityBundle.swift
+++ b/TranscriptionLiveActivity/TranscriptionLiveActivityBundle.swift
@@ -1,0 +1,15 @@
+import ActivityKit
+import WidgetKit
+import SwiftUI
+
+/// Bundle configuration for the transcription live activity widgets
+///
+/// This bundle registers all live activity widgets and configurations for the
+/// transcription app. It provides the entry point for ActivityKit to discover
+/// and manage live activities across different iOS presentation contexts.
+@main
+struct TranscriptionLiveActivityBundle: WidgetBundle {
+    var body: some Widget {
+        TranscriptionLiveActivity()
+    }
+}


### PR DESCRIPTION
Start a LiveActivity on iOS to display transcription result in dynamic island/lockscreen widget
* An indicator to show if there is active voice, animates from light to dark color when voice is detected
* Update hypothesis result
* Shows information when mic is interrupted